### PR TITLE
Fix for ESP8266

### DIFF
--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -240,7 +240,7 @@ uint8_t Adafruit_CCS811::read8(byte reg)
 void Adafruit_CCS811::_i2c_init()
 {
 	Wire.begin();
-	#ifdef ARDUINO_ESP8266_NODEMCU
+	#ifdef ESP8266
 	Wire.setClockStretchLimit(500);
 	#endif
 }

--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -240,7 +240,9 @@ uint8_t Adafruit_CCS811::read8(byte reg)
 void Adafruit_CCS811::_i2c_init()
 {
 	Wire.begin();
-	Wire.setClockStretchLimit(500); //Fix for ESP8266
+	#ifdef ARDUINO_ESP8266_NODEMCU
+	Wire.setClockStretchLimit(500);
+	#endif
 }
 
 void Adafruit_CCS811::read(uint8_t reg, uint8_t *buf, uint8_t num)

--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -121,8 +121,8 @@ void Adafruit_CCS811::setEnvironmentalData(uint8_t humidity, double temperature)
 	humidity would be 0x61, 0x00.*/
 	
 	/* Temperature is stored as an unsigned 16 bits integer in 1/512
-	degrees; there is an offset: 0 maps to -25°C. The default value is
-	25°C = 0x64, 0x00. As an example 23.5% temperature would be
+	degrees; there is an offset: 0 maps to -25Â°C. The default value is
+	25Â°C = 0x64, 0x00. As an example 23.5% temperature would be
 	0x61, 0x00.
 	The internal algorithm uses these values (or default values if
 	not set by the application) to compensate for changes in
@@ -240,6 +240,7 @@ uint8_t Adafruit_CCS811::read8(byte reg)
 void Adafruit_CCS811::_i2c_init()
 {
 	Wire.begin();
+	Wire.setClockStretchLimit(500); //Fix for ESP8266
 }
 
 void Adafruit_CCS811::read(uint8_t reg, uint8_t *buf, uint8_t num)


### PR DESCRIPTION
ESP8266 Arduino Library uses a default I2C timeout value that is too short for the CCS811. This seems to fix reading errors from esp8255 i2c.