### PR TITLE
Deprecate calculateTemperature

### DIFF
--- a/examples/CCS811_test/CCS811_test.ino
+++ b/examples/CCS811_test/CCS811_test.ino
@@ -1,5 +1,5 @@
 /***************************************************************************
-  This is a library for the CCS811 air 
+  This is a library for the CCS811 air
 
   This sketch reads the sensor
 
@@ -22,30 +22,25 @@ Adafruit_CCS811 ccs;
 
 void setup() {
   Serial.begin(9600);
-  
+
   Serial.println("CCS811 test");
-  
+
   if(!ccs.begin()){
     Serial.println("Failed to start sensor! Please check your wiring.");
     while(1);
   }
 
-  //calibrate temperature sensor
+  // Wait for the sensor to be ready
   while(!ccs.available());
-  float temp = ccs.calculateTemperature();
-  ccs.setTempOffset(temp - 25.0);
 }
 
 void loop() {
   if(ccs.available()){
-    float temp = ccs.calculateTemperature();
     if(!ccs.readData()){
       Serial.print("CO2: ");
       Serial.print(ccs.geteCO2());
       Serial.print("ppm, TVOC: ");
       Serial.print(ccs.getTVOC());
-      Serial.print("ppb   Temp:");
-      Serial.println(temp);
     }
     else{
       Serial.println("ERROR!");


### PR DESCRIPTION
Hardware support for external thermistor removed by vendor. Remove calls to `calculateTemperature()` from example and update docstring.