### PR TITLE
Add possibility to pass wire object to use non-default I2C pins

### DIFF
--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -1,4 +1,16 @@
 #include "Adafruit_CCS811.h"
+#include <Wire.h>
+
+/**************************************************************************/
+/*!
+ * @brief  CCS811 constructor using i2c
+ * @param  *theWire
+ *         optional wire
+ */
+/**************************************************************************/
+Adafruit_CCS811::Adafruit_CCS811(TwoWire *theWire) {
+  _wire = theWire;
+}
 
 /**************************************************************************/
 /*!
@@ -236,9 +248,9 @@ uint8_t Adafruit_CCS811::read8(byte reg) {
 }
 
 void Adafruit_CCS811::_i2c_init() {
-  Wire.begin();
+  _wire->begin();
 #ifdef ESP8266
-  Wire.setClockStretchLimit(500);
+  _wire->setClockStretchLimit(500);
 #endif
 }
 
@@ -250,21 +262,21 @@ void Adafruit_CCS811::read(uint8_t reg, uint8_t *buf, uint8_t num) {
   while (pos < num) {
 
     uint8_t read_now = min((uint8_t)32, (uint8_t)(num - pos));
-    Wire.beginTransmission((uint8_t)_i2caddr);
-    Wire.write((uint8_t)reg + pos);
-    Wire.endTransmission();
-    Wire.requestFrom((uint8_t)_i2caddr, read_now);
+    _wire->beginTransmission((uint8_t)_i2caddr);
+    _wire->write((uint8_t)reg + pos);
+    _wire->endTransmission();
+    _wire->requestFrom((uint8_t)_i2caddr, read_now);
 
     for (int i = 0; i < read_now; i++) {
-      buf[pos] = Wire.read();
+      buf[pos] = _wire->read();
       pos++;
     }
   }
 }
 
 void Adafruit_CCS811::write(uint8_t reg, uint8_t *buf, uint8_t num) {
-  Wire.beginTransmission((uint8_t)_i2caddr);
-  Wire.write((uint8_t)reg);
-  Wire.write((uint8_t *)buf, num);
-  Wire.endTransmission();
+  _wire->beginTransmission((uint8_t)_i2caddr);
+  _wire->write((uint8_t)reg);
+  _wire->write((uint8_t *)buf, num);
+  _wire->endTransmission();
 }

--- a/Adafruit_CCS811.h
+++ b/Adafruit_CCS811.h
@@ -66,7 +66,7 @@ enum {
 class Adafruit_CCS811 {
 public:
   // constructors
-  Adafruit_CCS811(void){};
+  Adafruit_CCS811(TwoWire *theWire = &Wire);
   ~Adafruit_CCS811(void){};
 
   bool begin(uint8_t addr = CCS811_ADDRESS);
@@ -119,6 +119,7 @@ public:
   bool checkError();
 
 private:
+  TwoWire *_wire; /**< Wire object */
   uint8_t _i2caddr;
   float _tempOffset;
 

--- a/examples/CCS811_rewire/CCS811_rewire.ino
+++ b/examples/CCS811_rewire/CCS811_rewire.ino
@@ -1,0 +1,75 @@
+/*
+  Andrey Lutich
+  Example of rewiring Adafruit_CCS811 I2C to non-default pins (33, 25)
+  Tested on ESP32
+
+  Based on:
+  Rui Santos
+  Complete project details at https://RandomNerdTutorials.com/esp32-i2c-communication-arduino-ide/
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files.
+  
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+*/
+
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include "Adafruit_CCS811.h"
+
+#define I2C_SDA 33
+#define I2C_SCL 25
+
+
+TwoWire I2CBMP = TwoWire(0);
+Adafruit_CCS811 ccs(&I2CBMP);
+
+unsigned long delayTime;
+
+void setup() {
+  Serial.begin(9600);
+  I2CBMP.begin(I2C_SDA, I2C_SCL, 100000);
+
+  Serial.println("CCS811 test");
+  if(!ccs.begin()){
+    Serial.println("Failed to start sensor! Please check your wiring.");
+    while(1);
+  }
+
+  // Wait for the sensor to be ready
+  while(!ccs.available());
+  
+  delayTime = 1000;
+
+  Serial.println("Setup... done.");
+}
+
+void loop() { 
+  printValues();
+  delay(delayTime);
+}
+
+void printValues() {
+    Serial.println("CCS811:");
+    if(ccs.available()){
+      if(!ccs.readData()){
+        
+        Serial.print("CO2: ");
+        Serial.print(ccs.geteCO2());
+        Serial.println("ppm");
+
+        Serial.print("TVOC: ");
+        Serial.print(ccs.getTVOC());
+        Serial.println("ppb");
+      }
+      else{
+        Serial.println("ERROR!");
+        while(1);
+      }
+    }
+
+
+
+  Serial.println();
+}


### PR DESCRIPTION
Scope: add possibility to pass a Wire object for using other I2C pins.
Implementation: same way as in the Adafruit_BMP280 lib.
Limitations: nothing new compared to the top of the trunk.
Tests: test case added. Tested with ESP32.