### PR TITLE
Add support for getting and setting the baseline

### DIFF
--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -147,6 +147,40 @@ void Adafruit_CCS811::setEnvironmentalData(uint8_t humidity,
 
 /**************************************************************************/
 /*!
+    @brief  get the current baseline from the sensor.
+    @returns the baseline as 16 bit integer. This value is not human readable.
+*/
+/**************************************************************************/
+uint16_t Adafruit_CCS811::getBaseline() {
+  /* baseline is not in a human readable format, the two bytes are assembled
+  to an uint16_t for easy handling/passing around */
+
+  uint8_t buf[2];
+
+  this->read(CCS811_BASELINE, buf, 2);
+
+  return ((uint16_t)buf[0] << 8) | ((uint16_t)buf[1]);
+}
+
+/**************************************************************************/
+/*!
+    @brief  set the baseline for the sensor.
+    @param baseline the baseline to be set. Has to be a value retrieved by
+    getBaseline().
+*/
+/**************************************************************************/
+void Adafruit_CCS811::setBaseline(uint16_t baseline) {
+  /* baseline is not in a human readable format, byte ordering matches
+  getBaseline() */
+
+  uint8_t buf[] = {(uint8_t)((baseline >> 8) & 0xFF),
+                   (uint8_t)(baseline & 0xFF)};
+
+  this->write(CCS811_BASELINE, buf, 2);
+}
+
+/**************************************************************************/
+/*!
     @deprecated hardware support removed by vendor
     @brief  calculate the temperature using the onboard NTC resistor.
     @returns temperature as a double.

--- a/Adafruit_CCS811.h
+++ b/Adafruit_CCS811.h
@@ -73,6 +73,9 @@ public:
 
   void setEnvironmentalData(uint8_t humidity, double temperature);
 
+  uint16_t getBaseline();
+  void setBaseline(uint16_t baseline);
+
   // calculate temperature based on the NTC register
   double calculateTemperature();
 


### PR DESCRIPTION
This pull request adds support for getting/setting the sensor's baseline register.

According to Application Note AN000370 the "CCS811 calculates the eCO2 and eTVOC using the baseline as a reference point" and it won't save the baseline on it's own. Thus, when you bring up the sensor in polluted air you need to restore a baseline from a time when the sensor has been exposed to clean air. Otherwise, your readings will be wrong (based on wrong assumptions on part of the sensor). Again, see the Application Note for details.
