### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -5,14 +5,19 @@
     @brief  Setups the I2C interface and hardware and checks for communication.
     @param  addr Optional I2C address the sensor can be found on. Default is
    0x5A
+    @param theWire Optional pointer to I2C interface, &Wire is used by default
     @returns True if device is set up, false on any failure
 */
 /**************************************************************************/
 bool Adafruit_CCS811::begin(uint8_t addr, TwoWire *theWire) {
+
   i2c_dev = new Adafruit_I2CDevice(addr, theWire);
   if (!i2c_dev->begin()) {
     return false;
   }
+#ifdef ESP8266
+  Wire.setClockStretchLimit(500);
+#endif
 
   SWReset();
   delay(100);

--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -273,29 +273,8 @@ uint8_t Adafruit_CCS811::read8(byte reg) {
 }
 
 void Adafruit_CCS811::read(uint8_t reg, uint8_t *buf, uint8_t num) {
-  uint8_t buffer[1];
-  size_t chunkSize = i2c_dev->maxBufferSize();
-  uint8_t pos = 0;
-
-  if (chunkSize > num) {
-    // can just read
-    buffer[0] = reg;
-    i2c_dev->write(buffer, 1);
-    i2c_dev->read(buf, num);
-  } else {
-    // must read in chunks
-    uint8_t read_buffer[chunkSize];
-    while (pos < num) {
-      buffer[0] = reg + pos;
-      i2c_dev->write(buffer, 1);
-      uint8_t read_now = min(uint8_t(chunkSize), (uint8_t)(num - pos));
-      i2c_dev->read(read_buffer, read_now);
-      for (uint8_t i = 0; i < read_now; i++) {
-        buf[pos] = read_buffer[i];
-        pos++;
-      }
-    }
-  }
+  uint8_t buffer[1] = {reg};
+  i2c_dev->write_then_read(buffer, 1, buf, num);
 }
 
 void Adafruit_CCS811::write(uint8_t reg, uint8_t *buf, uint8_t num) {

--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -16,7 +16,7 @@ bool Adafruit_CCS811::begin(uint8_t addr, TwoWire *theWire) {
     return false;
   }
 #ifdef ESP8266
-  Wire.setClockStretchLimit(500);
+  theWire->setClockStretchLimit(500);
 #endif
 
   SWReset();

--- a/Adafruit_CCS811.h
+++ b/Adafruit_CCS811.h
@@ -7,7 +7,7 @@
 #include "WProgram.h"
 #endif
 
-#include <Wire.h>
+#include <Adafruit_I2CDevice.h>
 
 /*=========================================================================
     I2C ADDRESS/BITS
@@ -69,7 +69,7 @@ public:
   Adafruit_CCS811(void){};
   ~Adafruit_CCS811(void){};
 
-  bool begin(uint8_t addr = CCS811_ADDRESS);
+  bool begin(uint8_t addr = CCS811_ADDRESS, TwoWire *theWire = &Wire);
 
   void setEnvironmentalData(float humidity, float temperature);
 
@@ -140,7 +140,7 @@ public:
   bool checkError();
 
 private:
-  uint8_t _i2caddr;
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   float _tempOffset;
 
   uint16_t _TVOC;
@@ -155,7 +155,6 @@ private:
 
   void read(uint8_t reg, uint8_t *buf, uint8_t num);
   void write(uint8_t reg, uint8_t *buf, uint8_t num);
-  void _i2c_init();
 
   /*=========================================================================
           REGISTER BITFIELDS

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit CCS811 Library
-version=1.0.5
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit CCS811 I2C gas sensor breakout.
@@ -7,4 +7,4 @@ paragraph=CCS811 is a gas sensor that can detect a wide range of Volatile Organi
 category=Sensors
 url=https://github.com/adafruit/Adafruit_CCS811
 architectures=*
-depends=Adafruit SSD1306, Adafruit GFX Library
+depends=Adafruit SSD1306, Adafruit GFX Library, Adafruit BusIO


### PR DESCRIPTION
For #29. Converts to BusIO with no change to existing library API *except* added a `TwoWire` parameter to `begin()`, but sets a default so should be backwards compatible.

Tested on Qt PY with `CCS811_test` example sketch from library.
![Screenshot from 2021-08-10 10-59-35](https://user-images.githubusercontent.com/8755041/128911018-731a0034-455b-41b7-8976-382f32f832c3.png)
