### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_CCS811.cpp
+++ b/Adafruit_CCS811.cpp
@@ -1,5 +1,10 @@
 #include "Adafruit_CCS811.h"
 
+Adafruit_CCS811::~Adafruit_CCS811(void) {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
 /**************************************************************************/
 /*!
     @brief  Setups the I2C interface and hardware and checks for communication.
@@ -10,7 +15,8 @@
 */
 /**************************************************************************/
 bool Adafruit_CCS811::begin(uint8_t addr, TwoWire *theWire) {
-
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(addr, theWire);
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_CCS811.h
+++ b/Adafruit_CCS811.h
@@ -67,7 +67,7 @@ class Adafruit_CCS811 {
 public:
   // constructors
   Adafruit_CCS811(void){};
-  ~Adafruit_CCS811(void){};
+  ~Adafruit_CCS811(void);
 
   bool begin(uint8_t addr = CCS811_ADDRESS, TwoWire *theWire = &Wire);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit CCS811 Library
-version=1.1.0
+version=1.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit CCS811 I2C gas sensor breakout.


### PR DESCRIPTION
Tested on Qt PY. This sensor returns `0`s for the first few readings. So spamming calls to `begin()` in a loop is generally not a good idea. But memory leak issue fixed for those that must.

Test sketch.
```cpp
#include "Adafruit_CCS811.h"

Adafruit_CCS811 ccs;

void setup() {
  Serial.begin(9600);
  while (!Serial);

  Serial.println("CCS811 test");
}

void loop() {
  if(!ccs.begin()){
    Serial.println("Failed to start sensor! Please check your wiring.");
    while(1);
  }
  
  while(!ccs.available());

  Serial.println("Getting 10 readings...");
  
  for (uint8_t i=0; i<10; i++) {
    if(!ccs.readData()){
      Serial.print("CO2: ");
      Serial.print(ccs.geteCO2());
      Serial.print("ppm, TVOC: ");
      Serial.println(ccs.getTVOC());
    } else {
      Serial.println("no data");
    }
    delay(1000);
  }
```

![Screenshot from 2021-09-02 10-11-29](https://user-images.githubusercontent.com/8755041/131887710-23c69599-0a42-4d4a-8d43-62bf9218deb4.png)
